### PR TITLE
Replace placeholder links in landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,18 +29,18 @@
 </head>
 <body class="bg-gray-50">
     <!-- Header -->
-    <header class="bg-white shadow-md">
+    <header id="home" class="bg-white shadow-md">
         <div class="container mx-auto px-4 py-4 flex justify-between items-center">
             <div class="flex items-center">
                 <div class="bg-red-600 text-white px-3 py-1 rounded-md font-bold text-xl mr-2">377</div>
                 <h1 class="text-xl font-bold text-gray-800">کد 377 مدیران خودرو نجفی گل</h1>
             </div>
             <nav class="hidden md:flex space-x-6 space-x-reverse">
-                <a href="#" class="text-gray-700 hover:text-red-600">صفحه اصلی</a>
-                <a href="#" class="text-gray-700 hover:text-red-600">محصولات</a>
-                <a href="#" class="text-gray-700 hover:text-red-600">خدمات</a>
-                <a href="#" class="text-gray-700 hover:text-red-600">درباره ما</a>
-                <a href="#" class="text-gray-700 hover:text-red-600">تماس با ما</a>
+                <a href="#home" class="text-gray-700 hover:text-red-600">صفحه اصلی</a>
+                <a href="#products" class="text-gray-700 hover:text-red-600">محصولات</a>
+                <a href="#services" class="text-gray-700 hover:text-red-600">خدمات</a>
+                <a href="#about" class="text-gray-700 hover:text-red-600">درباره ما</a>
+                <a href="#contact" class="text-gray-700 hover:text-red-600">تماس با ما</a>
             </nav>
             <button class="md:hidden text-gray-700">
                 <i class="fas fa-bars text-xl"></i>
@@ -56,7 +56,7 @@
                 <p class="text-lg mb-6 leading-relaxed">
                     🚗ماشینتو اقساطی بخر🚗 — فروش : 1-05133448000 | خدمات پس از فروش : 05191099420 | خیابان کوشش (گاراژدارها) - نبش کوشش ۲۴، مشهد
                 </p>
-                <a href="#" class="bg-white text-red-600 px-6 py-2 rounded-md font-bold hover:bg-gray-100 transition duration-300 inline-block">
+                <a href="#about" class="bg-white text-red-600 px-6 py-2 rounded-md font-bold hover:bg-gray-100 transition duration-300 inline-block">
                     بیشتر بخوانید
                 </a>
             </div>
@@ -67,7 +67,7 @@
     </section>
 
     <!-- Services Section -->
-    <section class="py-16 bg-white">
+    <section id="services" class="py-16 bg-white">
         <div class="container mx-auto px-4">
             <h2 class="text-3xl font-bold text-center mb-12 text-gray-800">خدمات کد 377 مدیران خودرو نجفی گل</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -104,7 +104,7 @@
     </section>
 
     <!-- Car Finder Section -->
-    <section class="py-16 bg-gray-100">
+    <section id="about" class="py-16 bg-gray-100">
         <div class="container mx-auto px-4">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-8 md:mb-0">
@@ -115,7 +115,7 @@
                     <p class="text-gray-600 mb-6">
                         کد 377 مدیران خودرو نجفی گل به وسیله کارشناسان متخصص به شما کمک می‌کند تا براساس بودجه و ویژگی‌های مدنظر خود، خودروی متناسب با نیازتان را مقایسه و انتخاب کنید.
                     </p>
-                    <a href="#" class="bg-red-600 text-white px-6 py-2 rounded-md font-bold hover:bg-red-700 transition duration-300 inline-block">
+                    <a href="#contact" class="bg-red-600 text-white px-6 py-2 rounded-md font-bold hover:bg-red-700 transition duration-300 inline-block">
                         مشاوره رایگان
                     </a>
                 </div>
@@ -127,7 +127,7 @@
     </section>
 
     <!-- Featured Cars -->
-    <section class="py-16 bg-white">
+    <section id="products" class="py-16 bg-white">
         <div class="container mx-auto px-4">
             <h2 class="text-3xl font-bold text-center mb-12 text-gray-800">محصولات ما</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
@@ -255,7 +255,7 @@
             </div>
             
             <div class="text-center mt-12">
-                <a href="#" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
+                <a href="javascript:void(0)" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
                     مشاهده تمام محصولات
                 </a>
             </div>
@@ -362,7 +362,7 @@
             </div>
             
             <div class="mt-8 text-center">
-                <a href="#" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
+                <a href="javascript:void(0)" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
                     مشاهده لیست کامل قیمت‌ها
                 </a>
             </div>
@@ -373,28 +373,28 @@
     <section class="py-16 bg-gray-100">
         <div class="container mx-auto px-4">
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <a href="#" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
+                <a href="javascript:void(0)" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
                     <div class="text-red-600 mb-4">
                         <i class="fas fa-car text-4xl"></i>
                     </div>
                     <h3 class="text-xl font-semibold mb-2">پیدا کردن خودرو</h3>
                     <p class="text-gray-600">پیدا کردن خودروی مناسب بر اساس نیاز شما</p>
                 </a>
-                <a href="#" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
+                <a href="javascript:void(0)" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
                     <div class="text-red-600 mb-4">
                         <i class="fas fa-calculator text-4xl"></i>
                     </div>
                     <h3 class="text-xl font-semibold mb-2">محاسبه اقساط</h3>
                     <p class="text-gray-600">محاسبه اقساط خودرو با شرایط مختلف</p>
                 </a>
-                <a href="#" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
+                <a href="javascript:void(0)" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
                     <div class="text-red-600 mb-4">
                         <i class="fas fa-exchange-alt text-4xl"></i>
                     </div>
                     <h3 class="text-xl font-semibold mb-2">فروش خودرو</h3>
                     <p class="text-gray-600">فروش خودروی قبلی و خرید خودروی جدید</p>
                 </a>
-                <a href="#" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
+                <a href="javascript:void(0)" class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition duration-300 text-center">
                     <div class="text-red-600 mb-4">
                         <i class="fas fa-book text-4xl"></i>
                     </div>
@@ -414,7 +414,7 @@
                     <p class="text-gray-600 mb-6">
                         در این طرح کلیه دارندگان خودروهای برندهای ام وی ام، فونیکس، اکستریم و حتی برند های مطرح داخلی و خارجی که سال ساخت خودروی آنها از سال 1395 به بعد می باشد می توانند با مراجعه به وب‌سایت کد 377 مدیران خودرو نجفی گل و تکمیل فرم رزرو ثبت نام، نسبت به ثبت درخواست جایگزینی خودروی خود اقدام نمایند.
                     </p>
-                    <a href="#" class="bg-red-600 text-white px-6 py-2 rounded-md font-bold hover:bg-red-700 transition duration-300 inline-block">
+                    <a href="javascript:void(0)" class="bg-red-600 text-white px-6 py-2 rounded-md font-bold hover:bg-red-700 transition duration-300 inline-block">
                         اطلاعات بیشتر
                     </a>
                 </div>
@@ -439,7 +439,7 @@
                         <p class="text-gray-600 mb-4">
                             بررسی بازار خودروهای برقی در ایران و مقایسه با نمونه های خارجی
                         </p>
-                        <a href="#" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
+                        <a href="javascript:void(0)" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
                             بیشتر بخوانید
                             <i class="fas fa-arrow-left mr-2"></i>
                         </a>
@@ -454,7 +454,7 @@
                         <p class="text-gray-600 mb-4">
                             مقایسه کامل مشخصات فنی و امکانات این دو خودروی پرطرفدار
                         </p>
-                        <a href="#" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
+                        <a href="javascript:void(0)" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
                             بیشتر بخوانید
                             <i class="fas fa-arrow-left mr-2"></i>
                         </a>
@@ -469,7 +469,7 @@
                         <p class="text-gray-600 mb-4">
                             معرفی کامل و بررسی تخصصی خودروی جدید چری در بازار ایران
                         </p>
-                        <a href="#" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
+                        <a href="javascript:void(0)" class="text-red-600 font-semibold hover:text-red-700 transition duration-300 inline-flex items-center">
                             بیشتر بخوانید
                             <i class="fas fa-arrow-left mr-2"></i>
                         </a>
@@ -478,7 +478,7 @@
             </div>
             
             <div class="text-center mt-12">
-                <a href="#" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
+                <a href="javascript:void(0)" class="inline-block bg-gray-800 text-white px-6 py-3 rounded-md font-bold hover:bg-gray-700 transition duration-300">
                     مشاهده تمام مقالات
                 </a>
             </div>
@@ -498,13 +498,13 @@
                         🚗ماشینتو اقساطی بخر🚗 — فروش : 1-05133448000 | خدمات پس از فروش : 05191099420 | خیابان کوشش (گاراژدارها) - نبش کوشش ۲۴، مشهد
                     </p>
                     <div class="flex space-x-4 space-x-reverse">
-                        <a href="#" class="text-gray-400 hover:text-white transition duration-300">
+                        <a href="javascript:void(0)" class="text-gray-400 hover:text-white transition duration-300">
                             <i class="fab fa-instagram text-xl"></i>
                         </a>
-                        <a href="#" class="text-gray-400 hover:text-white transition duration-300">
+                        <a href="javascript:void(0)" class="text-gray-400 hover:text-white transition duration-300">
                             <i class="fab fa-telegram text-xl"></i>
                         </a>
-                        <a href="#" class="text-gray-400 hover:text-white transition duration-300">
+                        <a href="javascript:void(0)" class="text-gray-400 hover:text-white transition duration-300">
                             <i class="fab fa-whatsapp text-xl"></i>
                         </a>
                     </div>
@@ -512,11 +512,11 @@
                 <div>
                     <h3 class="text-lg font-semibold mb-4">لینک‌های سریع</h3>
                     <ul class="space-y-2">
-                        <li><a href="#" class="text-gray-400 hover:text-white transition duration-300">صفحه اصلی</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-white transition duration-300">محصولات</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-white transition duration-300">خدمات</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-white transition duration-300">درباره ما</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-white transition duration-300">تماس با ما</a></li>
+                        <li><a href="#home" class="text-gray-400 hover:text-white transition duration-300">صفحه اصلی</a></li>
+                        <li><a href="#products" class="text-gray-400 hover:text-white transition duration-300">محصولات</a></li>
+                        <li><a href="#services" class="text-gray-400 hover:text-white transition duration-300">خدمات</a></li>
+                        <li><a href="#about" class="text-gray-400 hover:text-white transition duration-300">درباره ما</a></li>
+                        <li><a href="#contact" class="text-gray-400 hover:text-white transition duration-300">تماس با ما</a></li>
                     </ul>
                 </div>
                 <div>
@@ -566,7 +566,7 @@
     </footer>
 
     <!-- WhatsApp Float Button -->
-    <a href="#" class="fixed bottom-6 left-6 bg-green-500 text-white p-3 rounded-full shadow-lg hover:bg-green-600 transition duration-300 z-50">
+    <a href="javascript:void(0)" class="fixed bottom-6 left-6 bg-green-500 text-white p-3 rounded-full shadow-lg hover:bg-green-600 transition duration-300 z-50">
         <i class="fab fa-whatsapp text-2xl"></i>
     </a>
 
@@ -575,7 +575,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             const mobileMenuButton = document.querySelector('button[class*="md:hidden"]');
             const navMenu = document.querySelector('nav[class*="hidden md:flex"]');
-            
+
             mobileMenuButton.addEventListener('click', function() {
                 navMenu.classList.toggle('hidden');
                 navMenu.classList.toggle('flex');
@@ -590,6 +590,12 @@
                 navMenu.classList.toggle('space-y-4');
                 navMenu.classList.remove('space-x-6');
                 navMenu.classList.remove('space-x-reverse');
+            });
+
+            document.querySelectorAll('a[href="javascript:void(0)"]').forEach(function(anchor) {
+                anchor.addEventListener('click', function(event) {
+                    event.preventDefault();
+                });
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- link navigation to page sections instead of `#`
- use `javascript:void(0)` for placeholders and prevent default clicks

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cb22466483269cd91d68bda67b62